### PR TITLE
The Davis.Request constructor will now ignore the host and protocol parts of a full URL.

### DIFF
--- a/src/davis.request.js
+++ b/src/davis.request.js
@@ -54,8 +54,14 @@ Davis.Request = function (raw) {
     });
   };
 
+  raw.fullPath = raw.fullPath.replace(/^https?:\/\/.+?\//, '/');
+
   this.method = (this.params._method || raw.method).toLowerCase();
-  this.path = raw.fullPath.replace(/\?.+$/, "");
+
+  this.path = raw.fullPath
+    .replace(/\?.+$/, "")  // Remove the query string
+    .replace(/^https?:\/\/[^\/]+/, ""); // Remove the protocol and host parts
+
   this.delegateToServer = raw.delegateToServer || Davis.noop;
   this.isForPageLoad = raw.forPageLoad || false;
 

--- a/tests/test_request.js
+++ b/tests/test_request.js
@@ -10,6 +10,11 @@ test("request without any params", function () {
   same({}, request.params, "should have no params");
 });
 
+test("request with a full url", function() {
+  var request = factory('request', {fullPath: 'http://www-1.example.com:80/users/john-smith.html'});
+  equal(request.location(), '/users/john-smith.html', "should remove the host and protocol parts");
+});
+
 test("request with params", function () {
   var request = factory('request', {
     method: 'post',


### PR DESCRIPTION
This is a patch for the issue referenced in https://github.com/olivernn/davis.js/issues/5#issuecomment-1941747.  It simply strips out the hostname and protocol parts from the source url.  I have some more thoughts that I'll include in the original issue.
