### PR TITLE
Hash routing

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,11 +23,13 @@
     <script src="/src/davis.request.js"></script>
     <script src="/src/davis.event.js"></script>
     <script src="/src/davis.app.js"></script>
+    <script src="/src/extensions/davis.hashRouting.js"></script>
 
     <!-- Tests -->
     <script src="/tests/test_route.js"></script>
     <script src="/tests/test_router.js"></script>
     <script src="/tests/test_history.js"></script>
+    <script src="/tests/test_hashRouting.js"></script>
     <script src="/tests/test_request.js"></script>
     <script src="/tests/test_event.js"></script>
     <script src="/tests/test_app.js"></script>

--- a/src/extensions/davis.hashRouting.js
+++ b/src/extensions/davis.hashRouting.js
@@ -37,6 +37,10 @@
  *
  * `prefix`. This string will be prepended to all hash locations. This defaults to ''
  *
+ * `pollerInterval`. Sets the interval in milliseconds that the window.location object will be polled
+ *  for changes in the hash. This is irrelevant for browsers that support the onhashchange event. 
+ *  This defaults to 100.
+ *
  * @plugin
  */
 Davis.hashRouting = function(options) {
@@ -54,6 +58,9 @@ Davis.hashRouting = function(options) {
 
   if(typeof(options.normalizeInitialLocation) == 'undefined')
     options.normalizeInitialLocation = true;
+
+  if(typeof(options.pollerInterval) == 'undefined')
+    options.pollerInterval = 100;
 
   /**
     * options.location should be the same as window.location.  This option is
@@ -77,7 +84,7 @@ Davis.hashRouting = function(options) {
     if("onhashchange" in window) {
       jQuery(window).bind('hashchange', checkForLocationChange);
     } else {
-      setTimeout(locationPoller, pollerInterval);
+      setTimeout(locationPoller, options.pollerInterval);
     }
   };
 
@@ -170,7 +177,6 @@ Davis.hashRouting = function(options) {
     * On browsers that don't support the onhashchange event, we poll
     * window.location to detect a change
     */
-  var pollerInterval = 500;
   getLocation = function() {
     return options.location.hash;
   };
@@ -184,7 +190,7 @@ Davis.hashRouting = function(options) {
 
   var locationPoller = function() {
     checkForLocationChange();
-    setTimeout(locationPoller, pollerInterval);
+    setTimeout(locationPoller, options.pollerInterval);
   };
 
   /**

--- a/src/extensions/davis.hashRouting.js
+++ b/src/extensions/davis.hashRouting.js
@@ -62,6 +62,9 @@ Davis.hashRouting = function(options) {
   if(typeof(options.pollerInterval) == 'undefined')
     options.pollerInterval = 100;
 
+  if(typeof(options.forcePolling) == 'undefined')
+    options.forcePolling = false;
+
   /**
     * options.location should be the same as window.location.  This option is
     * available for the sake of test mocking.
@@ -81,7 +84,7 @@ Davis.hashRouting = function(options) {
    * @private
    */
   var bindHashChange = function() {
-    if("onhashchange" in window) {
+    if("onhashchange" in window && !options.forcePolling) {
       jQuery(window).bind('hashchange', checkForLocationChange);
     } else {
       setTimeout(locationPoller, options.pollerInterval);

--- a/src/extensions/davis.hashRouting.js
+++ b/src/extensions/davis.hashRouting.js
@@ -9,106 +9,245 @@
  * hash based approach.  It implements the delegate methods of Davis.location however it has some limitations
  * when compared with the default pushState based routing.
  *
- * Firstly there is nothing similar to the history.replaceState method available when using location.hash, this
- * means that doing redirects always adds a new entry in the history rather than replacing the current history
- * entry.
- *
- * Secondly it is not possible to have multiple history entries of the same location as the hashchange event
- * only fires when the hash changes to a different value.
+ * It is not possible to have multiple history entries of the same location as the hashchange event only fires
+ * when the hash changes to a different value.
  *
  * This extension could be used to provide a fallback for browsers that do not support the HTML5 history api,
  * however this extension does not take into account what happens when a hash link is used in a browser that
  * supports HTML5 history.
  *
+ * When this extension is instantiated, the browser will be redirected to the appropriate location scheme.
+ * For example, if the current URL is "http://www.example.com/foobar" but the browser doesn't support
+ * the history api, it will be redirected to "http://www.example.com/#!/foobar".
+ *
+ * If this extension is instantiated on a browser that supports the history API, then the hash routing will
+ * not take effect unless the forceHashRouting option is set to true
+ *
  * To use this extension put this code at before starting your app.
  *
- *    Davis.extend(Davis.hashRouting)
+ *    Davis.extend(Davis.hashRouting({ prefix: "!" }))
+ *
+ * The extention takes a number of options:
+ *
+ * `forceHashRouting` Setting this to true will force hash routing, even if the browser supports 
+ *  the history API.  This defaults to false.
+ *
+ * `normalizeInitialLocation` - If this is true, then the browser will be redirected to the appropriate routing
+ *  as soon as the extension is initialized.  This defaults to true.
+ *
+ * `prefix`. This string will be prepended to all hash locations. This defaults to '!'
  *
  * @plugin
  */
-Davis.hashRouting = function () {
+Davis.hashRouting = function(options) {
+  if(!options)
+    options = {};
 
   /**
-   * ## Davis.supported
-   * Overwriting the supported because we are interested in the onhashchange event only now.
-   */
-  Davis.supported = function () {
-    return ("onhashchange" in window)
-  }
+    * Configuring option defaults
+    */
+  if(typeof(options.forceHashRouting) == 'undefined')
+    options.forceHashRouting = false;
+
+  if(typeof(options.prefix) == 'undefined')
+    options.prefix = "!";
+
+  if(typeof(options.normalizeInitialLocation) == 'undefined')
+    options.normalizeInitialLocation = "!";
 
   /**
-   * Setting the location delegate to be this hashRouting module
+    * options.location should be the same as window.location.  This option is
+    * available for the sake of test mocking.
+    */
+  if(typeof(options.location) == 'undefined')
+    options.location = window.location;
+
+  /**
+   * Storage for callbacks
+   * @private
    */
-  Davis.location.setLocationDelegate((function () {
+  var callbacks = [];
 
-    /**
-     * Storage for callbacks
-     * @private
-     */
-    var callbacks = []
+  /**
+   * Binds to the onhashchange event if it is available. If this event isn't support,
+   * a poller will be started to monitor the hash location for changes.
+   * @private
+   */
+  var bindHashChange = function() {
+    if("onhashchange" in window) {
+      jQuery(window).bind('hashchange', checkForLocationChange);
+    } else {
+      setTimeout(locationPoller, pollerInterval);
+    }
+  };
 
-    /**
-     * ## Davis.hashRouting.current
-     *
-     * Returns the apps current location, which for hashRouting is pulled from the location.hash.
-     * Davis.location delegates to this method for getting the apps current location.
-     */
-    var current = function () {
-      var hash
-      if (hash = window.location.hash.replace(/^#/, "")) {
-        return hash
+  var invokeCallbacks = function(request) {
+    Davis.utils.forEach(callbacks, function (callback) {
+      callback(request);
+    });
+  };
+
+  /**
+   * ## Davis.hashRouting.onChange
+   *
+   * Adds callbacks to the hashchange event.  Davis.location delegates to this method when asinging
+   * callbacks for when the apps location has changed.
+   *
+   * @param {Function} the callback to be fired when the location has changed.
+   */
+  var onChange = function(handler) {
+    callbacks.push(handler);
+  };
+
+  var hashLocationPattern = new RegExp("#" + options.prefix + "(.*)$")
+
+  /**
+   * ## Davis.hashRouting.current
+   *
+   * Returns the apps current location, which for hashRouting is pulled from the location.hash.
+   * Davis.location delegates to this method for getting the apps current location.
+   */
+  var current = function() {
+    var match = options.location.hash.match(hashLocationPattern);
+    if(match)
+      return match[1];
+    else
+      return '/';
+  };
+
+  var onHashChange = function() {
+    var path = current();
+
+    if(path) {
+      invokeCallbacks( new Davis.Request({
+          fullPath: path,
+          method: "get"
+        })
+      );
+    }
+  };
+
+  /**
+   * ## normalize
+   *
+   * Give the hash and non-hash parts of a location, this returns a URL
+   * that will fit into the current routing schema.
+   *
+   * @private
+   */
+  var normalize = function(usingHashRouting, hashLocation, normalLocation) {
+    if(hashLocation && hashLocation != '/') {
+      if(usingHashRouting) {
+        if(normalLocation != '/') {
+          /*
+            URL looks like:          http://www.example.com/foo#!/bar
+            We want it to look like: http://www.example.com/#!/bar
+          */
+          return "/#!" + hashLocation;
+        }
       } else {
-        return "/"
+        /*
+          URL looks like:          http://www.example.com/foo#!/bar
+          We want it to look like: http://www.example.com/bar
+        */
+        return hashLocation;
+      }
+    } else {
+      if(usingHashRouting && normalLocation != '/') {
+        /*
+          URL looks like:          http://www.example.com/foo
+          We want it to look like: http://www.example.com/#!/foo
+        */
+        return "/#!" + normalLocation;
       }
     }
 
-    /**
-     * ## Davis.hashRouting.assign
-     *
-     * Wrapper around changing the current location.hash.  This will also trigger all onChange callbacks
-     * that have been registered.  Davis.location delegates to this method for setting the apps current
-     * location as well as replacing the current location for the app with a new location.
-     *
-     * @params {Request} the request to set the current location to.
+    /* URL is find the way it is.  Don't forward anywhere */
+    return null;
+  };
+
+  /**
+    * On browsers that don't support the onhashchange event, we poll
+    * window.location to detect a change
+    */
+  var pollerInterval = 500;
+  getLocation = function() {
+    return options.location.hash;
+  };
+  var lastPolledLocation = getLocation();
+  var checkForLocationChange = function() {
+    if(lastPolledLocation != getLocation()) {
+      lastPolledLocation = getLocation();
+      onHashChange();
+    }
+  };
+
+  var locationPoller = function() {
+    checkForLocationChange();
+    setTimeout(locationPoller, pollerInterval);
+  };
+
+  /**
+   * ## Davis.hashRouting.assign and replace
+   *
+   * Wrapper around location.assign and location.replace.  This will also trigger all onChange callbacks
+   * that have been registered.  Davis.location delegates to this method for setting the apps current
+   * location as well as replacing the current location for the app with a new location.
+   *
+   * @params {Request} the request to set the current location to.
+   */
+  var wrapper = function(request, setter) {
+    setter("/#" + options.prefix + request.location());
+    lastPolledLocation = getLocation();
+    invokeCallbacks(request);
+  };
+
+  var assign = function(request) {
+    wrapper(request, function(string) {
+      // IE does not allow you to use call or apply on location.replace or location.assign.
+      // Keep this in mind if refactoring.
+      options.location.assign(string);
+    });
+  };
+
+  var replace = function(request) {
+    wrapper(request, function(string) {
+      options.location.replace(string);
+    });
+  };
+
+  return function(Davis) {
+    /*
+     * By default, don't enable this extension if the browser supports the history api. 
      */
-    var assign = function (request) {
-      if (request.location()) {
-        window.location.hash = request.location()
-      } else {
-        callbacks.forEach(function (callback) {
-          callback(request)
-        })
-      };
+    var usingHashRouting = !Davis.supported() || options.forceHashRouting;
+
+    /*
+     * Forward the web browser to a normalized version of the current URL, if necessary.
+     */
+    if(options.normalizeInitialLocation) {
+      normalizedLocation = normalize(usingHashRouting, current(), options.location.pathname);
+      if(normalizedLocation) {
+        options.location.replace(normalizedLocation);
+      }
     }
 
-    /**
-     * ## Davis.hashRouting.onChange
-     *
-     * Adds callbacks to the hashchange event.  Davis.location delegates to this method when asinging
-     * callbacks for when the apps location has changed.
-     *
-     * @param {Function} the callback to be fired when the location has changed.
-     */
-    var onChange = function (callback) {
-      callbacks.push(callback)
-
-      jQuery(window).bind('hashchange', function (e) {
-        callback(new Davis.Request({
-          fullPath: current(),
-          method: 'get'
-        }))
-      })
-    }
+    if(!usingHashRouting)
+      return;
 
     /**
-     * Exposing the public methods of this module
-     * @private
+     * ## Davis.supported
+     * Overwriting supported because this extension will support any browser.
      */
-    return {
-      current: current,
+    Davis.supported = function () { return true; }
+
+    Davis.location.setLocationDelegate({
       assign: assign,
-      replace: assign,
+      current: current,
+      replace: replace,
       onChange: onChange
-    }
-  })())
-}
+    });
+
+    bindHashChange();
+  }
+};

--- a/src/extensions/davis.hashRouting.js
+++ b/src/extensions/davis.hashRouting.js
@@ -33,7 +33,7 @@
  *  the history API.  This defaults to false.
  *
  * `normalizeInitialLocation` - If this is true, then the browser will be redirected to the appropriate routing
- *  as soon as the extension is initialized.  This defaults to true.
+ *  as soon as the extension is initialized.  This defaults to false.
  *
  * `prefix`. This string will be prepended to all hash locations. This defaults to ''
  *
@@ -57,7 +57,7 @@ Davis.hashRouting = function(options) {
     options.prefix = '';
 
   if(typeof(options.normalizeInitialLocation) == 'undefined')
-    options.normalizeInitialLocation = true;
+    options.normalizeInitialLocation = false;
 
   if(typeof(options.pollerInterval) == 'undefined')
     options.pollerInterval = 100;

--- a/src/extensions/davis.hashRouting.js
+++ b/src/extensions/davis.hashRouting.js
@@ -18,7 +18,7 @@
  *
  * When this extension is instantiated, the browser will be redirected to the appropriate location scheme.
  * For example, if the current URL is "http://www.example.com/foobar" but the browser doesn't support
- * the history api, it will be redirected to "http://www.example.com/#!/foobar".
+ * the history api, it will be redirected to "http://www.example.com/#/foobar".
  *
  * If this extension is instantiated on a browser that supports the history API, then the hash routing will
  * not take effect unless the forceHashRouting option is set to true
@@ -35,7 +35,7 @@
  * `normalizeInitialLocation` - If this is true, then the browser will be redirected to the appropriate routing
  *  as soon as the extension is initialized.  This defaults to true.
  *
- * `prefix`. This string will be prepended to all hash locations. This defaults to '!'
+ * `prefix`. This string will be prepended to all hash locations. This defaults to ''
  *
  * @plugin
  */
@@ -50,10 +50,10 @@ Davis.hashRouting = function(options) {
     options.forceHashRouting = false;
 
   if(typeof(options.prefix) == 'undefined')
-    options.prefix = "!";
+    options.prefix = '';
 
   if(typeof(options.normalizeInitialLocation) == 'undefined')
-    options.normalizeInitialLocation = "!";
+    options.normalizeInitialLocation = true;
 
   /**
     * options.location should be the same as window.location.  This option is
@@ -143,7 +143,7 @@ Davis.hashRouting = function(options) {
             URL looks like:          http://www.example.com/foo#!/bar
             We want it to look like: http://www.example.com/#!/bar
           */
-          return "/#!" + hashLocation;
+          return "/#" + options.prefix + hashLocation;
         }
       } else {
         /*
@@ -158,7 +158,7 @@ Davis.hashRouting = function(options) {
           URL looks like:          http://www.example.com/foo
           We want it to look like: http://www.example.com/#!/foo
         */
-        return "/#!" + normalLocation;
+        return "/#" + options.prefix + normalLocation;
       }
     }
 

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -9,3 +9,22 @@ var currentPathname = function (pathname, message) {
 var resetLocation = function () {
   window.history.replaceState({}, '', '/')
 }
+
+var createSpy = function() {
+  var spy = function() {
+    spy.mostRecentCall = { object: this, args: arguments };
+    spy.calls.push(spy.mostRecentCall);
+    spy.callCount++;
+    spy.wasCalled = true;
+  };
+
+  spy.reset = function() {
+    spy.wasCalled = false;
+    spy.callCount = 0;
+    spy.calls = [];
+  };
+
+  spy.reset();
+
+  return spy;
+};

--- a/tests/test_hashRouting.js
+++ b/tests/test_hashRouting.js
@@ -34,7 +34,7 @@ test("location delegate", function() {
   var onChangeCallback = createSpy();
   locationDelegate.onChange(onChangeCallback);
 
-  mockLocation.hash = "#!/somewhere_else"
+  mockLocation.hash = "#/somewhere_else"
   jQuery(window).trigger('hashchange');
   ok(onChangeCallback.wasCalled);
 
@@ -49,7 +49,7 @@ test("location delegate", function() {
 
   ok(onChangeCallback.wasCalled);
   ok(mockLocation.assign.wasCalled);
-  equal(mockLocation.assign.mostRecentCall.args[0], '/#!/hello_assign_test');
+  equal(mockLocation.assign.mostRecentCall.args[0], '/#/hello_assign_test');
 
   /**
     * Test replace
@@ -62,7 +62,7 @@ test("location delegate", function() {
 
   ok(onChangeCallback.wasCalled);
   ok(mockLocation.replace.wasCalled);
-  equal(mockLocation.replace.mostRecentCall.args[0], '/#!/hello_replace_test');
+  equal(mockLocation.replace.mostRecentCall.args[0], '/#/hello_replace_test');
 });
 
 test("normalizing the initial value of window.location", function() {
@@ -70,7 +70,7 @@ test("normalizing the initial value of window.location", function() {
   /**
     * test helper
     */
-  function normalizationTest(forceHashRouting, pathname, hash) {
+  function normalizationTest(forceHashRouting, pathname, hash, prefix) {
     var mockLocation = {
       pathname: pathname,
       hash: hash,
@@ -79,7 +79,8 @@ test("normalizing the initial value of window.location", function() {
 
     var extension = Davis.hashRouting({
       forceHashRouting: forceHashRouting,
-      location: mockLocation
+      location: mockLocation,
+      prefix: prefix
     });
 
     extension(Davis);
@@ -95,10 +96,10 @@ test("normalizing the initial value of window.location", function() {
   /**
     * Test when history API is supported
     */
-  result = normalizationTest(false, '/foo', '#!/bar');
+  result = normalizationTest(false, '/foo', '#/bar');
   equal(result, '/bar');
 
-  result = normalizationTest(false, '/', '#!/foobar');
+  result = normalizationTest(false, '/', '#/foobar');
   equal(result, '/foobar');
 
   result = normalizationTest(false, '/foobar', '');
@@ -108,12 +109,19 @@ test("normalizing the initial value of window.location", function() {
     * Test when history API is not supported
     */
   result = normalizationTest(true, '/woot', '');
-  ok(result == '/#!/woot');
+  equal(result, '/#/woot');
 
-  result = normalizationTest(true, '/woot', '#!/foobar');
-  ok(result == '/#!/foobar');
+  result = normalizationTest(true, '/woot', '#/foobar');
+  equal(result, '/#/foobar');
 
-  result = normalizationTest(true, '/', '#!/foobar');
+  result = normalizationTest(true, '/woot', '', '!');
+  equal(result, '/#!/woot');
+
+
+  result = normalizationTest(true, '/woot', '#!/foobar', '!');
+  equal(result, '/#!/foobar');
+
+  result = normalizationTest(true, '/', '#/foobar');
   equal(result, null);
 
   // Cleanup

--- a/tests/test_hashRouting.js
+++ b/tests/test_hashRouting.js
@@ -80,6 +80,7 @@ test("normalizing the initial value of window.location", function() {
     var extension = Davis.hashRouting({
       forceHashRouting: forceHashRouting,
       location: mockLocation,
+      normalizeInitialLocation: true,
       prefix: prefix
     });
 

--- a/tests/test_hashRouting.js
+++ b/tests/test_hashRouting.js
@@ -1,0 +1,121 @@
+module('hashRouting Extension');
+
+test("location delegate", function() {
+  mockDavis = { 
+    location: {
+      setLocationDelegate: createSpy()
+    },
+    supported: function() { return true; }
+  };
+
+  var mockLocation = {
+    pathname: '/',
+    hash: '#',
+    assign: createSpy(),
+    replace: createSpy(),
+  };
+
+  var extension = Davis.hashRouting({
+    forceHashRouting: true,
+    location: mockLocation
+  });
+
+  extension(mockDavis);
+
+  /**
+    * Extension should set a new location delegate
+    */
+  ok(mockDavis.location.setLocationDelegate.wasCalled);
+  locationDelegate = mockDavis.location.setLocationDelegate.mostRecentCall.args[0];
+
+  /**
+    * Test onChange callback
+    */
+  var onChangeCallback = createSpy();
+  locationDelegate.onChange(onChangeCallback);
+
+  mockLocation.hash = "#!/somewhere_else"
+  jQuery(window).trigger('hashchange');
+  ok(onChangeCallback.wasCalled);
+
+  /**
+    * Test assign
+    */
+  onChangeCallback.reset();
+  mockLocation.assign.reset();
+
+  var request = new Davis.Request({ fullPath: '/hello_assign_test', method: 'get' });
+  locationDelegate.assign(request);
+
+  ok(onChangeCallback.wasCalled);
+  ok(mockLocation.assign.wasCalled);
+  equal(mockLocation.assign.mostRecentCall.args[0], '/#!/hello_assign_test');
+
+  /**
+    * Test replace
+    */
+  onChangeCallback.reset();
+  mockLocation.assign.reset();
+
+  var request = new Davis.Request({ fullPath: '/hello_replace_test', method: 'get' });
+  locationDelegate.replace(request);
+
+  ok(onChangeCallback.wasCalled);
+  ok(mockLocation.replace.wasCalled);
+  equal(mockLocation.replace.mostRecentCall.args[0], '/#!/hello_replace_test');
+});
+
+test("normalizing the initial value of window.location", function() {
+
+  /**
+    * test helper
+    */
+  function normalizationTest(forceHashRouting, pathname, hash) {
+    var mockLocation = {
+      pathname: pathname,
+      hash: hash,
+      replace: createSpy()
+    };
+
+    var extension = Davis.hashRouting({
+      forceHashRouting: forceHashRouting,
+      location: mockLocation
+    });
+
+    extension(Davis);
+
+    if(mockLocation.replace.mostRecentCall)
+      return mockLocation.replace.mostRecentCall.args[0];
+    else
+      return null;
+  }
+
+  var result;
+
+  /**
+    * Test when history API is supported
+    */
+  result = normalizationTest(false, '/foo', '#!/bar');
+  equal(result, '/bar');
+
+  result = normalizationTest(false, '/', '#!/foobar');
+  equal(result, '/foobar');
+
+  result = normalizationTest(false, '/foobar', '');
+  equal(result, null);
+
+  /**
+    * Test when history API is not supported
+    */
+  result = normalizationTest(true, '/woot', '');
+  ok(result == '/#!/woot');
+
+  result = normalizationTest(true, '/woot', '#!/foobar');
+  ok(result == '/#!/foobar');
+
+  result = normalizationTest(true, '/', '#!/foobar');
+  equal(result, null);
+
+  // Cleanup
+  Davis.location.setLocationDelegate(Davis.history);
+});


### PR DESCRIPTION
This pull request references issue #7

The default prefix is now an empty string.  I also found a few places that I hardcoded a "!", so that was a good exercise.

The pollerInterval is now configurable and defaults to 100ms.

The location normalization is definitely ugly business.  I wanted to expose it in some way to the API consumer, otherwise they would end up with URLs that looks like `http://www.example.com/one_thing#/another_thing`.  I wanted this extension to just make all the ugliness go away (as much as possible).  For now, I've set the default to false.
