### PR TITLE
Added Facebook Like Button Extension

### DIFF
--- a/src/extensions/davis.fblike.js
+++ b/src/extensions/davis.fblike.js
@@ -1,0 +1,30 @@
+/*!
+ * Davis - fblike
+ * Copyright (C) 2011 Hannu Leinonen
+ * MIT Licensed
+ */
+
+/**
+ * Davis.fblike is an extension to Davis that will update the Facebook like 
+ * button's target to the current page the user is viewing or a predefined path.
+ * 
+ * To use this extension put code similar to one of these examples before 
+ * starting your app.
+ * 
+ *     Davis.extend(Davis.fblike)
+ *     Davis.extend(Davis.fblike("/foo/bar"))
+ *     Davis.extend(Davis.fblike("http://example.com/foo/bar"))
+ * 
+ * @plugin
+ */
+Davis.fblike = function(path) {
+	path = path ? path.match(/^https?:\/\/.+/) === null ? 
+			window.location.protocol + "//" + window.location.host + path : path : null;
+	
+	return function(Davis) {
+		Davis.event.bind('routeComplete', function(req) {
+			if (req.method == 'get' && path)
+				$('div.fb-like').attr('data-href', path);
+		});
+	};
+}

--- a/src/plugins/davis.mixpanel.js
+++ b/src/plugins/davis.mixpanel.js
@@ -1,0 +1,62 @@
+/*!
+ * Davis - mixpanel
+ * Copyright (C) 2011 Oliver Nightingale, Hannu Leinonen
+ * MIT Licensed
+ */
+
+/**
+ * Davis.mixpanel is a plugin to track Davis requests in Mixpanel.  It automatically
+ * tracks every GET request and adds helpers to manually track other requests and to prevent a
+ * particular request from being tracked.
+ *
+ * To include this plugin in your application first include a script tag for it. Find the Mixpanel
+ * script and find the part containing.
+ *    
+ *    d=["init","track","track_links","track_forms","register","register_once","identify","name_tag","set_config"];
+ *     
+ * Modify the Mixpanel script by adding "track_pageview" to the list.
+ * 
+ *    d=["init","track","track_links","track_forms","track_pageview","register","register_once","identify","name_tag","set_config"];
+ *                                                 ^   ADD THIS!   ^
+ * 
+ * Then in your app do the following.
+ *
+ *    this.use(Davis.mixpanel)
+ *
+ * @plugin
+ */
+Davis.mixpanel = function () {
+
+  /**
+   * whether a route should be tracked or not
+   * @private
+   */
+  var shouldTrack = true
+
+  /**
+   * bind to the apps routeComplete event and track the request unless explicitly told not to.
+   * @private
+   */
+  this.bind('routeComplete', function (req) {
+    if (shouldTrack && req.method == 'get') req.track()
+    shouldTrack = true
+  })
+
+  this.helpers({
+    /**
+     * ## request.noTrack
+     * Disable tracking for this request
+     */
+    noTrack: function () {
+      shouldTrack = false
+    },
+
+    /**
+     * ## request.track
+     * Track this request in mixpanel
+     */
+    track: function () {
+      if (mpq) mpq.track_pageview()
+    }
+  })
+}


### PR DESCRIPTION
Added extension for managing the Facebook Like Button, e.g. forcing it to be always the same or follow the current path.

PS. I had no idea how to exclude the earlier commit which is included in the pull request #21 from this pull request.
