### PR TITLE
listener: Allow user to open new tabs by holding Ctrl while clicking a link

### DIFF
--- a/lib/davis.listener.js
+++ b/lib/davis.listener.js
@@ -51,6 +51,10 @@ Davis.listener = function () {
    */
   var handler = function (targetExtractor) {
     return function (event) {
+      // Allow user to open new tabs by holding Ctrl while clicking a link
+      if(event.ctrlKey) {
+        return true;
+      }
       if (differentOrigin(this)) return true
       var request = new Davis.Request (targetExtractor.call(Davis.$(this)));
       Davis.location.assign(request)


### PR DESCRIPTION
Capturing all clicks regardless of modifier keys breaks basic expected browser behavior, specifically allowing a new tab to be opened. Middle button mouse button still works as expected. This patch causes the davis listener to ignore ctrl+clicks on links, thereby restoring expected behavior.

Note: I am not sure if that's the correct modifier key for Mac OS. I'd appreciate if somebody with access to a Mac could verify that.
