### PR TITLE
toArray: Remove redundant local variable

### DIFF
--- a/davis.js
+++ b/davis.js
@@ -223,8 +223,7 @@ Davis.utils = (function () {
    * @returns {Array}
    */
   var toArray = function (args, start) {
-    var start = start || 0
-    return Array.prototype.slice.call(args, start)
+    return Array.prototype.slice.call(args, start || 0);
   }
 
   /*!


### PR DESCRIPTION
```
var start = start || 0;
call(start);
```

Variable 'start' already declared (as function argument).

```
start = start || 0;
call(start);
```

Variable only used once.

```
call(start || 0);
```
