### PR TITLE
Application stop bug fix

### DIFF
--- a/lib/davis.app.js
+++ b/lib/davis.app.js
@@ -216,5 +216,25 @@ Davis.App = (function () {
     this.running = false
   };
 
+  /**
+   * Destroys the app.
+   *
+   * Stops the app and cleans itself from any DOM interaction bringing it back to an unconfigured state.
+   */
+  App.prototype.destroy = function() {    
+    this.stop();
+
+    if (this.boundToInternalEvents) {
+      this
+        .unbind('runRoute')
+        .unbind('routeNotFound')
+        .unbind('start')
+        .unbind('stop')
+        .unbind('routeError');
+
+      this.boundToInternalEvents = false;
+	}
+  };
+
   return App;
 })()

--- a/lib/davis.app.js
+++ b/lib/davis.app.js
@@ -213,24 +213,9 @@ Davis.App = (function () {
    * apps settings.
    */
   App.prototype.stop = function() {
-    var self = this;
-    
-    var unbindInternalEvents = function () {
-      self
-        .unbind('runRoute')
-        .unbind('routeNotFound')
-        .unbind('start')
-        .unbind('stop')
-        .unbind('routeError');
-
-      self.boundToInternalEvents = false;
-    };
-
     this.unlisten();
     this.trigger('stop')
     this.running = false
-	
-    if (this.boundToInternalEvents) unbindInternalEvents();
   };
 
   /**

--- a/lib/davis.app.js
+++ b/lib/davis.app.js
@@ -138,6 +138,8 @@ Davis.App = (function () {
     }
 
     var handleRequest = function (request) {
+      if (!self.running) return;
+
       if (beforeFiltersPass(request)) {
         self.trigger('lookupRoute', request)
         var route = self.lookupRoute(request.method, request.path);
@@ -211,9 +213,24 @@ Davis.App = (function () {
    * apps settings.
    */
   App.prototype.stop = function() {
+    var self = this;
+    
+    var unbindInternalEvents = function () {
+      self
+        .unbind('runRoute')
+        .unbind('routeNotFound')
+        .unbind('start')
+        .unbind('stop')
+        .unbind('routeError');
+
+      self.boundToInternalEvents = false;
+    };
+
     this.unlisten();
     this.trigger('stop')
     this.running = false
+	
+    if (this.boundToInternalEvents) unbindInternalEvents();
   };
 
   return App;

--- a/lib/davis.event.js
+++ b/lib/davis.event.js
@@ -62,4 +62,18 @@ Davis.event = function () {
 
     return this;
   };
+
+ /**
+  * Unbinds all the callbacks from an event.
+  *
+  * @param {String} event event name
+  * @memberOf event
+  */
+  this.unbind = function (event) {
+    if (callbacks[event]) {
+      delete callbacks[event];
+    }
+    
+    return this;
+  };
 }

--- a/lib/davis.event.js
+++ b/lib/davis.event.js
@@ -62,4 +62,18 @@ Davis.event = function () {
 
     return this;
   };
+  
+   /**
+  * Unbinds all the callbacks from an event.
+  *
+  * @param {String} event event name
+  * @memberOf event
+  */
+  this.unbind = function (event) {
+    if (callbacks[event]) {
+      delete callbacks[event];
+    }
+    
+    return this;
+  };
 }

--- a/tests/test_app.js
+++ b/tests/test_app.js
@@ -58,3 +58,18 @@ test("adding helpers to requests", function () {
   var req = factory('request')
   equal('bar', req.foo)
 })
+
+test("should cleanup internal events when stopped", function () {
+  var app = factory('app'),
+      unbindCount = 0;
+
+  app.unbind = function () {
+    unbindCount += 1;
+	return app;
+  }
+  
+  app.start();
+  app.destroy();
+  ok(!app.boundToInternalEvents, "should set the internal events flag to false");
+  equals(unbindCount, 5, "should unbind every internal events");
+})

--- a/tests/test_app.js
+++ b/tests/test_app.js
@@ -58,3 +58,18 @@ test("adding helpers to requests", function () {
   var req = factory('request')
   equal('bar', req.foo)
 })
+
+test("should cleanup internal events when stopped", function () {
+  var app = factory('app'),
+      unbindCount = 0;
+
+  app.unbind = function () {
+    unbindCount += 1;
+	return app;
+  }
+  
+  app.start();
+  app.stop();
+  ok(!app.boundToInternalEvents, "should set the internal events flag to false");
+  equals(unbindCount, 5, "should unbind every internal events");
+})

--- a/tests/test_event.js
+++ b/tests/test_event.js
@@ -38,3 +38,17 @@ test("passing data to an event handler", function () {
   same({blah: 'halb'}, moreCallbackData, "should pass the callback data through to the handler");
   same(events, callbackContext, "should have this set to the app object");
 })
+
+test("Unbindind an event", function () {
+  var events = factory('events'),
+      callbackCalled = false;
+
+  events.bind('foo', function () {
+    callbackCalled = true;
+  });
+
+  events.unbind('foo');
+  events.trigger('foo');
+
+  ok(!callbackCalled, "callback should have been unbound and not called when triggered");
+});


### PR DESCRIPTION
Fixed a problem where the application did not detach the internal events from it's callbacks registry when stopping.  This has the effect of calling the callbacks as many time as the application was started/stopped during the lifetime of an application.
