### PR TITLE
Fix form handling in IE 10.

### DIFF
--- a/lib/davis.listener.js
+++ b/lib/davis.listener.js
@@ -29,7 +29,14 @@ Davis.listener = function () {
     FORM: function (elem) {
       var a = document.createElement('a')
       a.href = elem.action
-      return this.A(a)
+
+      // a.host needs to be checked this convoluted way because of IE10, which sticks the port on
+      // the end of a.host as created above.
+      f = document.createElement("form")
+      f.action = window.location.href
+      a2 = document.createElement("a")
+      a2.href = f.action
+      return a.host !== a2.host || a.protocol !== a2.protocol
     }
   }
 


### PR DESCRIPTION
In IE10, it seems that normal links are routed fine, but forms are not.
Minimal example: http://jsfiddle.net/xg4Hr/2/ - In Firefox and Chrome,
clicking the GET and POST buttons display "GET" and "POST" as you'd
expect. In IE10, the Davis.js routing is ignored and you get a 404
error. I narrowed the problem down to the `originChecks` function in
davis.listener.js, on this line:

```
a.href = elem.action
```

In Firefox and Chrome, this will make `a.host` equal to the domain
name. In IE10, the port number gets stuck on the end of `a.host`, for
some reason. This makes `this.A(a)` on the next line return false since
Davis.js thinks it is an external link. I worked around this by creating
`a2` to compare with `a`.
