### PR TITLE
Don't perform default action (page load / submit) if default prevented

### DIFF
--- a/lib/davis.listener.js
+++ b/lib/davis.listener.js
@@ -58,6 +58,7 @@ Davis.listener = function () {
     return function (event) {
       if (hasModifier(event)) return true
       if (differentOrigin(this)) return true
+      if (event.isDefaultPrevented()) return true
 
       var request = new Davis.Request (targetExtractor.call(Davis.$(this)));
       Davis.location.assign(request)


### PR DESCRIPTION
As of right now, anchors that have an onclick event attached will always fire the Davis route, no matter if the onclick handler returns false or calls event.preventDefault(). Attached change fixes that.
